### PR TITLE
ModDevGradle / Performance Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,12 @@ java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
 
+mixin {
+    add(sourceSets.main, "${mod_id}.refmap.json")
+
+    config("mixins.${mod_id}.json")
+}
+
 legacyForge {
     version = "${minecraft_version}-${forge_version}"
 
@@ -173,15 +179,6 @@ repositories {
 }
 
 dependencies {
-    // Specify the version of Minecraft to use.
-    // Any artifact can be supplied so long as it has a "userdev" classifier artifact and is a compatible patcher artifact.
-    // The "userdev" classifier will be requested and setup by ForgeGradle.
-    // If the group id is "net.minecraft" and the artifact id is one of ["client", "server", "joined"],
-    // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
-    annotationProcessor("org.spongepowered:mixin:0.8.5:processor")
-
-    // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
-    // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
     modCompileOnly("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
     modCompileOnly("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
     //modRuntimeOnly("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
@@ -223,7 +220,7 @@ dependencies {
         transitive = false
         exclude group: 'org.joml', module: ''
     }
-    implementation("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}") {
+    modImplementation("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}") {
         transitive = false
         exclude group: 'org.valkyrienskies.core', module: ''
     }
@@ -262,11 +259,17 @@ dependencies {
     modCompileOnly("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_version}")
     modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}")
     modImplementation("com.tterrag.registrate:Registrate:${registrate_version}")
-    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
-    implementation("io.github.llamalad7:mixinextras-forge:0.4.1")
 
     modImplementation("curse.maven:puzzles-lib-495476:6918565")
     modImplementation("curse.maven:easy-anvils-682567:5156621")
+
+    compileOnly 'org.jetbrains:annotations:26.0.2-1'
+
+    // Mixin
+    annotationProcessor("org.spongepowered:mixin:0.8.5:processor")
+    compileOnly "io.github.llamalad7:mixinextras-common:0.3.5"
+    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.3.5"))
+    annotationProcessor "io.github.llamalad7:mixinextras-common:0.3.5"
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.minecraftforge.gradle' version '[6.0,6.2)'
-    id 'org.parchmentmc.librarian.forgegradle' version '1.+'
-    id 'org.spongepowered.mixin' version '0.7.+'
+    id 'net.neoforged.moddev.legacyforge' version '2.0.91'
 }
 
 version = mod_version
@@ -14,114 +12,64 @@ base {
     archivesName = mod_id
 }
 
-// Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
-minecraft {
-    // The mappings can be changed at any time and must be in the following format.
-    // Channel:   Version:
-    // official   MCVersion             Official field/method names from Mojang mapping files
-    // parchment  YYYY.MM.DD-MCVersion  Open community-sourced parameter names and javadocs layered on top of official
-    //
-    // You must be aware of the Mojang license when using the 'official' or 'parchment' mappings.
-    // See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
-    //
-    // Parchment is an unofficial project maintained by ParchmentMC, separate from MinecraftForge
-    // Additional setup is needed to use their mappings: https://parchmentmc.org/docs/getting-started
-    //
-    // Use non-default mappings at your own risk. They may not always work.
-    // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: mapping_channel, version: mapping_version
-    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
-    // When true, this property will have all Eclipse/IntelliJ IDEA run configurations run the "prepareX" task for the given run configuration before launching the game.
-    // In most cases, it is not necessary to enable.
-    // enableEclipsePrepareRuns = true
-    // enableIdeaPrepareRuns = true
+legacyForge {
+    version = "${minecraft_version}-${forge_version}"
 
-    // This property allows configuring Gradle's ProcessResources task(s) to run on IDE output locations before launching the game.
-    // It is REQUIRED to be set to true for this template to function.
-    // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
-    copyIdeResources = true
+    parchment {
+        minecraftVersion = parchment_minecraft
+        mappingsVersion = parchment_version
+    }
 
-    // When true, this property will add the folder name of all declared run configurations to generated IDE run configurations.
-    // The folder name can be set on a run configuration using the "folderName" property.
-    // By default, the folder name of a run configuration is the name of the Gradle project containing it.
-    // generateRunFolders = true
-
-    // This property enables access transformers for use in development.
-    // They will be applied to the Minecraft artifact.
-    // The access transformer file can be anywhere in the project.
-    // However, it must be at "META-INF/accesstransformer.cfg" in the final mod jar to be loaded by Forge.
-    // This default location is a best practice to automatically put the file in the right place in the final jar.
-    // See https://docs.minecraftforge.net/en/latest/advanced/accesstransformers/ for more information.
-    // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
-
-    // Default run configurations.
-    // These can be tweaked, removed, or duplicated as needed.
     runs {
-        // applies to all the run configs below
-        configureEach {
-            workingDirectory project.file('run')
-
-            // Recommended logging data for a userdev environment
-            // The markers can be added/remove as needed separated by commas.
-            // "SCAN": For mods scan.
-            // "REGISTRIES": For firing of registry events.
-            // "REGISTRYDUMP": For getting the contents of all registries.
-            property 'forge.logging.markers', 'REGISTRIES'
-
-            // Recommended logging level for the console
-            // You can set various levels here.
-            // Please read: https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels
-            property 'forge.logging.console.level', 'debug'
-
-            mods {
-                "${mod_id}" {
-                    source sourceSets.main
-                }
-            }
-        }
-
         client {
-            // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            property 'mixin.env.remapRefMap', 'true'
-            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
-            property 'forge.enabledGameTestNamespaces', mod_id
+            client()
+            systemProperty 'forge.enabledGameTestNamespaces', project.mod_id
         }
 
         server {
-            property 'forge.enabledGameTestNamespaces', mod_id
-            args '--nogui'
+            server()
+            programArgument '--nogui'
+            systemProperty 'forge.enabledGameTestNamespaces', project.mod_id
         }
 
-        // This run config launches GameTestServer and runs all registered gametests, then exits.
-        // By default, the server will crash when no gametests are provided.
-        // The gametest system is also enabled by default for other run configs under the /test command.
         gameTestServer {
-            property 'forge.enabledGameTestNamespaces', mod_id
+            type = "gameTestServer"
+            systemProperty 'forge.enabledGameTestNamespaces', project.mod_id
         }
 
         data {
-            // example of overriding the workingDirectory set in configureEach above
-            workingDirectory project.file('run-data')
+            data()
+            programArguments.addAll '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
+        }
 
-            // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+        configureEach {
+            systemProperty 'forge.logging.markers', 'REGISTRIES'
+
+            logLevel = org.slf4j.event.Level.DEBUG
+        }
+    }
+
+    mods {
+        "${mod_id}" {
+            sourceSet sourceSets.main
         }
     }
 }
 
-// Include resources generated by data generators.
-sourceSets.main.resources { srcDir 'src/generated/resources' }
+sourceSets.main.resources.srcDir 'src/generated/resources'
+
+configurations {
+    runtimeClasspath.extendsFrom localRuntime
+}
+obfuscation {
+    createRemappingConfiguration(configurations.localRuntime)
+}
 
 repositories {
-    // Put repositories for dependencies here
-    // ForgeGradle automatically adds the Forge maven and Maven Central for you
-
-    // If you have mod jar dependencies in ./libs, you can declare them as a repository like so.
-    // See https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:flat_dir_resolver
     flatDir {
         dir 'libs'
     }
@@ -218,7 +166,6 @@ repositories {
                 url = "https://api.modrinth.com/maven"
             }
         }
-        forRepositories(fg.repository) // Only add this if you're using ForgeGradle, otherwise remove this line
         filter {
             includeGroup "maven.modrinth"
         }
@@ -231,35 +178,33 @@ dependencies {
     // The "userdev" classifier will be requested and setup by ForgeGradle.
     // If the group id is "net.minecraft" and the artifact id is one of ["client", "server", "joined"],
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
-    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-
-    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+    annotationProcessor("org.spongepowered:mixin:0.8.5:processor")
 
     // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
-    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
-    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
-    //runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
-    runtimeOnly fg.deobf("curse.maven:tmrv-1194921:6717421")
-    compileOnly fg.deobf("dev.emi:emi-forge:1.1.22+1.20.1:api")
-    runtimeOnly fg.deobf("dev.emi:emi-forge:1.1.22+1.20.1")
+    modCompileOnly("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
+    modCompileOnly("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
+    //modRuntimeOnly("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
+    modRuntimeOnly("curse.maven:tmrv-1194921:6717421")
+    modCompileOnly("dev.emi:emi-forge:1.1.22+1.20.1:api")
+    modRuntimeOnly("dev.emi:emi-forge:1.1.22+1.20.1")
 
-    runtimeOnly fg.deobf("curse.maven:curios-309927:6418456")
-    runtimeOnly fg.deobf("curse.maven:lionfish-api-1001614:5922047")
+    modRuntimeOnly("curse.maven:curios-309927:6418456")
+    modRuntimeOnly("curse.maven:lionfish-api-1001614:5922047")
 
-    runtimeOnly fg.deobf("curse.maven:lendercataclysm-551586:6906993")
+    modRuntimeOnly("curse.maven:lendercataclysm-551586:6906993")
 
-    runtimeOnly fg.deobf("curse.maven:v-tweaks-238048:7119159")
-    runtimeOnly fg.deobf("curse.maven:spartan-weaponry-278141:6842571")
-    runtimeOnly fg.deobf("curse.maven:bookling-gear-1122766:7317926")
-    runtimeOnly fg.deobf("curse.maven:lit-it-up-916334:7239006")
-    runtimeOnly fg.deobf("curse.maven:cupboard-326652:5470032")
-    runtimeOnly fg.deobf("curse.maven:recipe-essentials-forge-fabric-907856:6165709")
+    modRuntimeOnly("curse.maven:v-tweaks-238048:7119159")
+    modRuntimeOnly("curse.maven:spartan-weaponry-278141:6842571")
+    modRuntimeOnly("curse.maven:bookling-gear-1122766:7317926")
+    modRuntimeOnly("curse.maven:lit-it-up-916334:7239006")
+    modRuntimeOnly("curse.maven:cupboard-326652:5470032")
+    modRuntimeOnly("curse.maven:recipe-essentials-forge-fabric-907856:6165709")
 
-    runtimeOnly fg.deobf("curse.maven:caelus-308989:5281700")
-    runtimeOnly fg.deobf("curse.maven:attribute-setter-1064034:7196879")
+    modRuntimeOnly("curse.maven:caelus-308989:5281700")
+    modRuntimeOnly("curse.maven:attribute-setter-1064034:7196879")
 
-    runtimeOnly fg.deobf("curse.maven:geckolib-388172:7025129")
+    modRuntimeOnly("curse.maven:geckolib-388172:7025129")
 
     // region Valkyrien Skies
     implementation("org.valkyrienskies.core:api:${vs_core_version}") {
@@ -278,7 +223,7 @@ dependencies {
         transitive = false
         exclude group: 'org.joml', module: ''
     }
-    implementation fg.deobf("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}") {
+    implementation("org.valkyrienskies:valkyrienskies-120-forge:${vs2_version}") {
         transitive = false
         exclude group: 'org.valkyrienskies.core', module: ''
     }
@@ -288,40 +233,40 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.3"
     compileOnly("org.joml:joml:1.10.4")
     compileOnly("org.joml:joml-primitives:1.10.0")
-    implementation fg.deobf("thedarkcolour:kotlinforforge:4.11.0")
+    modImplementation("thedarkcolour:kotlinforforge:4.11.0")
 
     // endregion
     // Compile against only the API artifact
-    compileOnly(fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api"))
+    modCompileOnly("top.theillusivec4.curios:curios-forge:${curios_version}:api")
     // Use the full Curios API jar at runtime
-    runtimeOnly(fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}"))
+    modRuntimeOnly("top.theillusivec4.curios:curios-forge:${curios_version}")
 
-    runtimeOnly fg.deobf("curse.maven:selene-499980:6983934")
-    runtimeOnly fg.deobf("curse.maven:owo-lib-532610:4749199")
-    compileOnly fg.deobf("curse.maven:accessories-938917:7164863")
+    modRuntimeOnly("curse.maven:selene-499980:6983934")
+    modRuntimeOnly("curse.maven:owo-lib-532610:4749199")
+    modCompileOnly("curse.maven:accessories-938917:7164863")
 
-    implementation fg.deobf("dev.su5ed.sinytra.fabric-api:fabric-api-base:0.4.31+ef105b4977")
+    modImplementation("dev.su5ed.sinytra.fabric-api:fabric-api-base:0.4.31+ef105b4977")
 
-    implementation fg.deobf("dev.su5ed.sinytra.fabric-api:fabric-data-attachment-api-v1:1.0.0+30ef839e77")
-    implementation fg.deobf("dev.su5ed.sinytra.fabric-api:fabric-entity-events-v1:1.6.0+6274ab9d77")
-    implementation fg.deobf("dev.su5ed.sinytra.fabric-api:fabric-object-builder-api-v1:11.1.3+2174fc8477")
+    modImplementation("dev.su5ed.sinytra.fabric-api:fabric-data-attachment-api-v1:1.0.0+30ef839e77")
+    modImplementation("dev.su5ed.sinytra.fabric-api:fabric-entity-events-v1:1.6.0+6274ab9d77")
+    modImplementation("dev.su5ed.sinytra.fabric-api:fabric-object-builder-api-v1:11.1.3+2174fc8477")
 
-    runtimeOnly fg.deobf("curse.maven:immersive-armors-580681:6851704")
-    runtimeOnly fg.deobf("curse.maven:jade-324717:6855440")
+    modRuntimeOnly("curse.maven:immersive-armors-580681:6851704")
+    modRuntimeOnly("curse.maven:jade-324717:6855440")
 
-    runtimeOnly fg.deobf("curse.maven:cloth-config-348521:5729105")
-    runtimeOnly fg.deobf("curse.maven:architectury-api-419699:5137938")
+    modRuntimeOnly("curse.maven:cloth-config-348521:5729105")
+    modRuntimeOnly("curse.maven:architectury-api-419699:5137938")
 
-    implementation(fg.deobf("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false })
-    implementation(fg.deobf("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}"))
-    compileOnly(fg.deobf("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_version}"))
-    runtimeOnly(fg.deobf("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}"))
-    implementation(fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}"))
+    modImplementation("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
+    modImplementation("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}")
+    modCompileOnly("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_version}")
+    modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}")
+    modImplementation("com.tterrag.registrate:Registrate:${registrate_version}")
     compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
     implementation("io.github.llamalad7:mixinextras-forge:0.4.1")
 
-    implementation fg.deobf("curse.maven:puzzles-lib-495476:6918565")
-    implementation fg.deobf("curse.maven:easy-anvils-682567:5156621")
+    modImplementation("curse.maven:puzzles-lib-495476:6918565")
+    modImplementation("curse.maven:easy-anvils-682567:5156621")
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.
@@ -372,21 +317,23 @@ tasks.named('jar', Jar).configure {
 publishing {
     publications {
         register('mavenJava', MavenPublication) {
-            artifact jar
+            from components.java
         }
     }
     repositories {
         maven {
-            url "file://${project.projectDir}/mcmodsrepo"
+            url "file://${project.projectDir}/repo"
         }
     }
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
+    options.encoding = 'UTF-8'
 }
-mixin {
-    // MixinGradle Settings
-    add sourceSets.main, 'mixins.overgeared.refmap.json'
-    config 'mixins.overgeared.json'
+
+idea {
+    module {
+        downloadSources = true
+        downloadJavadoc = true
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ minecraft_version=1.20.1
 magitu=[9.23,)
 magitu_addon=[1.22,)
 slavic=[1.5,)
-minecraft_version_range=[1.20,1.20.1)
+minecraft_version_range=[1.20.1, 1.20.2)
 # The Forge version must agree with the Minecraft version to get a valid artifact
 forge_version=47.4.0
 # The Forge version range can use any version of Forge as bounds or match the loader version range

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,31 +11,18 @@ minecraft_version=1.20.1
 magitu=[9.23,)
 magitu_addon=[1.22,)
 slavic=[1.5,)
-minecraft_version_range=[1.20.1,1.21)
+minecraft_version_range=[1.20,1.20.1)
 # The Forge version must agree with the Minecraft version to get a valid artifact
 forge_version=47.4.0
 # The Forge version range can use any version of Forge as bounds or match the loader version range
 forge_version_range=[47,)
 # The loader version range can only use the major version of Forge/FML as bounds
 loader_version_range=[47,)
-# The mapping channel to use for mappings.
-# The default set of supported mapping channels are ["official", "snapshot", "snapshot_nodoc", "stable", "stable_nodoc"].
-# Additional mapping channels can be registered through the "channelProviders" extension in a Gradle plugin.
-#
-# | Channel   | Version              |                                                                                |
-# |-----------|----------------------|--------------------------------------------------------------------------------|
-# | official  | MCVersion            | Official field/method names from Mojang mapping files                          |
-# | parchment | YYYY.MM.DD-MCVersion | Open community-sourced parameter names and javadocs layered on top of official |
-#
-# You must be aware of the Mojang license when using the 'official' or 'parchment' mappings.
-# See more information here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md
-#
-# Parchment is an unofficial project maintained by ParchmentMC, separate from Minecraft Forge.
-# Additional setup is needed to use their mappings, see https://parchmentmc.org/docs/getting-started
-mapping_channel=parchment
-# The mapping version to query from the mapping channel.
-# This must match the format required by the mapping channel.
-mapping_version=2023.09.03-1.20.1
+
+# Parchment
+parchment_minecraft=1.20.1
+parchment_version=2023.09.03
+
 bucketlib_version=1.20.1-2.3.6.0
 bucketlib_version_range=[1.20.1-2.3.6.0,)
 jei_version=15.20.0.106

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,12 +3,12 @@ pluginManagement {
         gradlePluginPortal()
         maven {
             name = 'MinecraftForge'
-            url = 'https://maven.minecraftforge.net/'
+            url = 'https://files.minecraftforge.net/maven/'
         }
-        maven { url = 'https://maven.parchmentmc.org' } // Add this line
+        maven { url = 'https://maven.parchmentmc.org' }
     }
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }

--- a/src/main/java/net/stirdrem/overgeared/block/entity/AbstractSmithingAnvilBlockEntity.java
+++ b/src/main/java/net/stirdrem/overgeared/block/entity/AbstractSmithingAnvilBlockEntity.java
@@ -49,6 +49,8 @@ import static net.stirdrem.overgeared.OvergearedMod.getCooledItem;
 public abstract class AbstractSmithingAnvilBlockEntity extends BlockEntity implements MenuProvider {
     protected static final int INPUT_SLOT = 0;
     protected static final int OUTPUT_SLOT = 10;
+    protected boolean needsRecipeUpdate = true;
+    protected Optional<ForgingRecipe> cachedRecipe = Optional.empty();
     protected final ItemStackHandler itemHandler = new ItemStackHandler(12) {
         @Override
         protected void onContentsChanged(int slot) {
@@ -56,6 +58,7 @@ public abstract class AbstractSmithingAnvilBlockEntity extends BlockEntity imple
             if (!level.isClientSide()) {
                 level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), 3);
             }
+            needsRecipeUpdate = true;
         }
     };
 
@@ -592,14 +595,22 @@ public abstract class AbstractSmithingAnvilBlockEntity extends BlockEntity imple
     }
 
     public Optional<ForgingRecipe> getCurrentRecipe() {
-        SimpleContainer inventory = new SimpleContainer(this.itemHandler.getSlots());
-        for (int i = 0; i < 9; i++) {
-            inventory.setItem(i, itemHandler.getStackInSlot(i));
-        }
-        inventory.setItem(11, itemHandler.getStackInSlot(11));
+        if (level == null) return Optional.empty();
 
-        return ForgingRecipe.findBestMatch(level, inventory)
-                .filter(this::matchesRecipeExactly);
+        if (needsRecipeUpdate) {
+            SimpleContainer inventory = new SimpleContainer(this.itemHandler.getSlots());
+            for (int i = 0; i < 9; i++) {
+                inventory.setItem(i, itemHandler.getStackInSlot(i));
+            }
+            inventory.setItem(11, itemHandler.getStackInSlot(11));
+
+            cachedRecipe = ForgingRecipe.findBestMatch(level, inventory)
+                    .filter(this::matchesRecipeExactly);
+
+            needsRecipeUpdate = false;
+        }
+
+        return cachedRecipe;
     }
 
     protected boolean canInsertItemIntoOutputSlot(ItemStack stackToInsert) {


### PR DESCRIPTION
Hi! I was notified of a performance issue in waccyy's Fantasia caused by an interaction between one of my mods and Overgeared's anvil, I've fixed it on my end but I figured it makes sense to also add recipe caching on the side of Overgeared.

Here's the Spark report: https://spark.lucko.me/AxofCTSBBA. The main issue is Reliable Remover/Recipes, but it's being exacerbated by Overgeared's frequent recipe lookups.

Since recipe lookups are such an expensive operation, I added a simple recipe cache that should help with this.

I've also updated the buildscript to use ModDevGradle since ForgeGradle is now unsupported on 1.20 (and doesn't work for me anyway). You may have to clear the `.idea` folder in your IDE, or some textures in-game might be invisible.